### PR TITLE
fix: README: correct install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 To install the `gen-corim` command, do:
 
 ```
-$ go install github.com/veraison/services/gen-corim@latest
+$ go install github.com/veraison/gen-corim@latest
 ```
 
 ## Usage


### PR DESCRIPTION
The install commmand inside README.md was still using the old package name (when the tool was under services). Update with the correct package.