### PR TITLE
Update ccatoken and corim 

### DIFF
--- a/data/templates/cca/comid-template.json
+++ b/data/templates/cca/comid-template.json
@@ -15,6 +15,33 @@
         }
     ],
     "triples": {
-        "reference-values": []
+        "reference-values": [
+          {
+            "environment": {
+              "class": {
+                "id": {
+                  "type": "psa.impl-id",
+                  "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                },
+                "vendor": "ACME",
+                "model": "RoadRunner"
+              }
+            },
+            "measurements": [
+              {
+                "key": {
+                  "type": "cca.platform-config-id",
+                  "value": "cfg v1.0.0"
+                },
+                "value": {
+                  "raw-value": {
+                    "type": "bytes",
+                    "value": "AQID"
+                  }
+                }
+              }
+            ]
+          }
+        ]
     }
 }

--- a/data/templates/psa/comid-template.json
+++ b/data/templates/psa/comid-template.json
@@ -15,6 +15,33 @@
         }
     ],
     "triples": {
-        "reference-values": []
+        "reference-values": [
+          {
+            "environment": {
+              "class": {
+                "id": {
+                  "type": "psa.impl-id",
+                  "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                },
+                "vendor": "ACME",
+                "model": "RoadRunner"
+              }
+            },
+            "measurements": [
+              {
+                "key": {
+                  "type": "cca.platform-config-id",
+                  "value": "cfg v1.0.0"
+                },
+                "value": {
+                  "raw-value": {
+                    "type": "bytes",
+                    "value": "AQID"
+                  }
+                }
+              }
+            ]
+          }
+        ]
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.0.11
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.4
-	github.com/veraison/ccatoken v1.1.0
+	github.com/veraison/ccatoken v1.3.1
 	github.com/veraison/corim v1.1.3-0.20240827153408-de149e9b7682
 	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
-	github.com/veraison/psatoken v1.2.0
+	github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4
 )
 
 require (
@@ -30,7 +30,7 @@ require (
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7 // indirect
+	github.com/veraison/go-cose v1.3.0 // indirect
 	github.com/veraison/swid v1.1.1-0.20230911094910-8ffdd07a22ca // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.4
 	github.com/veraison/ccatoken v1.3.1
-	github.com/veraison/corim v1.1.3-0.20240827153408-de149e9b7682
+	github.com/veraison/corim v1.1.3-0.20241003171039-fe09de9f3764
 	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
 	github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4
 )

--- a/go.sum
+++ b/go.sum
@@ -64,10 +64,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/veraison/ccatoken v1.3.1 h1:zUHXr2mPprxMYv5Mm2mumxzQZ3I9wy7QGayXqa9Rv/E=
 github.com/veraison/ccatoken v1.3.1/go.mod h1:vMqdbW4H/8A3oT+24qssuIK3Aefy06XqzTELGg+gWAg=
-github.com/veraison/corim v1.1.2-0.20230912171018-eeb7bd486d3c h1:do1Yj0d4uq+Sd4PusgE8pfLfSKejJfaWukyjYTi8Ro0=
-github.com/veraison/corim v1.1.2-0.20230912171018-eeb7bd486d3c/go.mod h1:Vn9+tCyN2ljpQxYvM6rwu3hNqdVbWrdQ9hqMa1Jfxb0=
-github.com/veraison/corim v1.1.3-0.20240827153408-de149e9b7682 h1:oqsiJXorpD4fSYzQd969kUTW8G/xUNF69A4/F/OW2pw=
-github.com/veraison/corim v1.1.3-0.20240827153408-de149e9b7682/go.mod h1:sYmwruIqD5+83OcvMg6WUDTTWq8AWM6QbVQhbE9VFQM=
+github.com/veraison/corim v1.1.3-0.20241003171039-fe09de9f3764 h1:48GvCJSVsBDaqIiK0m+h4D9rhAwLlzias+F5oLId/Fg=
+github.com/veraison/corim v1.1.3-0.20241003171039-fe09de9f3764/go.mod h1:Wj3a6bSo7+3peVGjwGayHDALILh4PHMngDhgBYUbVLk=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53 h1:5gnX2TrGd/Xz8DOp2OaLtg/jLoIubSUTrgz6iZ58pJ4=
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/veraison/ccatoken v1.1.0 h1:U0Z5fOQRsdz3ksvvxVzTITczo+kfRxIlkWahJNP6Irs=
-github.com/veraison/ccatoken v1.1.0/go.mod h1:qh/KBwsrhPyGJqttlh8PU56wt1rPkUCX9A3ZAA/53Nc=
+github.com/veraison/ccatoken v1.3.1 h1:zUHXr2mPprxMYv5Mm2mumxzQZ3I9wy7QGayXqa9Rv/E=
+github.com/veraison/ccatoken v1.3.1/go.mod h1:vMqdbW4H/8A3oT+24qssuIK3Aefy06XqzTELGg+gWAg=
 github.com/veraison/corim v1.1.2-0.20230912171018-eeb7bd486d3c h1:do1Yj0d4uq+Sd4PusgE8pfLfSKejJfaWukyjYTi8Ro0=
 github.com/veraison/corim v1.1.2-0.20230912171018-eeb7bd486d3c/go.mod h1:Vn9+tCyN2ljpQxYvM6rwu3hNqdVbWrdQ9hqMa1Jfxb0=
 github.com/veraison/corim v1.1.3-0.20240827153408-de149e9b7682 h1:oqsiJXorpD4fSYzQd969kUTW8G/xUNF69A4/F/OW2pw=
@@ -71,11 +71,10 @@ github.com/veraison/corim v1.1.3-0.20240827153408-de149e9b7682/go.mod h1:sYmwruI
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53 h1:5gnX2TrGd/Xz8DOp2OaLtg/jLoIubSUTrgz6iZ58pJ4=
 github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
-github.com/veraison/go-cose v1.0.0-rc.1/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
-github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7 h1:KcKzBthSrSZIUEWBjVvkuk/DE3PyYFbXZxhx5byGFtc=
-github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7/go.mod h1:t6V8WJzHm1PD5HNsuDjW3KLv577uWb6UTzbZGvdQHD8=
-github.com/veraison/psatoken v1.2.0 h1:PeHy6YUbhFE9Z9xaQBoAMpMWUEqSHrF2JgfcwMTmFIA=
-github.com/veraison/psatoken v1.2.0/go.mod h1:2tHLoYMOIS4V4mO8MJT4VstRtpO50FLmhoOR35FyIr4=
+github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7rk=
+github.com/veraison/go-cose v1.3.0/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
+github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4 h1:N7qg7vDF2mUg7I+8AoU+ieJ20cgcShwFHXHkV5b2YAA=
+github.com/veraison/psatoken v1.2.1-0.20240719122628-26fe500fd5d4/go.mod h1:6+WZzXr0ACXYiUAJJqTaCxW43gY2+gEaCoVNdDv3+Bw=
 github.com/veraison/swid v1.1.1-0.20230911094910-8ffdd07a22ca h1:osmCKwWO/xM68Kz+rIXio1DNzEY2NdJOpGpoy5r8NlE=
 github.com/veraison/swid v1.1.1-0.20230911094910-8ffdd07a22ca/go.mod h1:d5jt76uMNbTfQ+f2qU4Lt8RvWOTsv6PFgstIM1QdMH0=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
To support the most recent token format, update ccatoken. And to be compatible with the latest veraison service, update CoRIM.

Tested by generating a CoRIM file from the latest evidence on the demo platform, provisioning a local veraison instance and performing verification.